### PR TITLE
fix 503 error if url contains ':'

### DIFF
--- a/impl/src/main/java/org/glassfish/exousia/AuthorizationService.java
+++ b/impl/src/main/java/org/glassfish/exousia/AuthorizationService.java
@@ -596,7 +596,7 @@ public class AuthorizationService {
         if (constrainedUriRequestAttribute != null) {
             String uri = (String) request.getAttribute(constrainedUriRequestAttribute);
             if (uri != null) {
-                return uri;
+                return uri.replace(":", "%3A");
             }
         }
 
@@ -605,7 +605,7 @@ public class AuthorizationService {
             return "";
         }
 
-        return relativeURI.replaceAll(":", "%3A");
+        return relativeURI.replace(":", "%3A");
     }
 
     private PrincipalMapper getOrCreatePrincipalMapper(String contextId, Supplier<PrincipalMapper> principalMapperSupplier) {


### PR DESCRIPTION
the url from attributeValue does not replace ':'. It will cause 503 error.

![image](https://github.com/eclipse-ee4j/exousia/assets/4328187/eed25693-c460-45a4-b29b-bc5c251efd2e)

btw: use replace method for performance..
