### PR TITLE
Support mixing in an additional set of (staged) permissions.

### DIFF
--- a/impl/src/main/java/module-info.java
+++ b/impl/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2023, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2019 OmniFaces. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -16,7 +16,7 @@
  */
 
 module org.glassfish.exousia {
-    
+
     exports org.glassfish.exousia;
     exports org.glassfish.exousia.constraints;
     exports org.glassfish.exousia.constraints.transformer;
@@ -31,8 +31,8 @@ module org.glassfish.exousia {
     opens org.glassfish.exousia.modules.def;
     opens org.glassfish.exousia.modules.locked;
     opens org.glassfish.exousia.permissions;
-    requires jakarta.servlet;
-    requires jakarta.security.jacc;
+    requires transitive jakarta.servlet;
+    requires transitive jakarta.security.jacc;
     requires java.logging;
     requires org.javassist;
     requires static java.management;

--- a/impl/src/main/java/org/glassfish/exousia/AuthorizationService.java
+++ b/impl/src/main/java/org/glassfish/exousia/AuthorizationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2023, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2019, 2021 OmniFaces. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -17,15 +17,6 @@
 
 package org.glassfish.exousia;
 
-import static jakarta.security.jacc.PolicyContext.HTTP_SERVLET_REQUEST;
-import static jakarta.security.jacc.PolicyContext.PRINCIPAL_MAPPER;
-import static jakarta.security.jacc.PolicyContext.SUBJECT;
-import static java.lang.System.Logger.Level.DEBUG;
-import static java.lang.System.Logger.Level.ERROR;
-import static java.util.Collections.emptySet;
-import static org.glassfish.exousia.constraints.transformer.ConstraintsToPermissionsTransformer.createResourceAndDataPermissions;
-import static org.glassfish.exousia.permissions.RolesToPermissionsTransformer.createWebRoleRefPermission;
-
 import jakarta.security.jacc.EJBMethodPermission;
 import jakarta.security.jacc.EJBRoleRefPermission;
 import jakarta.security.jacc.Policy;
@@ -40,11 +31,13 @@ import jakarta.security.jacc.WebRoleRefPermission;
 import jakarta.security.jacc.WebUserDataPermission;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletRequest;
+
 import java.lang.System.Logger;
 import java.lang.reflect.Method;
 import java.security.Permission;
 import java.security.Permissions;
 import java.security.Principal;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -52,13 +45,26 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
+
 import javax.security.auth.Subject;
+
 import org.glassfish.exousia.constraints.SecurityConstraint;
+import org.glassfish.exousia.constraints.transformer.StagedPermissionToConstraintResult;
+import org.glassfish.exousia.constraints.transformer.StagedPermissionsToConstraintsTransformer;
 import org.glassfish.exousia.mapping.DefaultPrincipalMapper;
 import org.glassfish.exousia.mapping.SecurityRoleRef;
 import org.glassfish.exousia.modules.def.DefaultPolicy;
 import org.glassfish.exousia.modules.def.DefaultPolicyConfigurationFactory;
 import org.glassfish.exousia.permissions.JakartaPermissions;
+
+import static jakarta.security.jacc.PolicyContext.HTTP_SERVLET_REQUEST;
+import static jakarta.security.jacc.PolicyContext.PRINCIPAL_MAPPER;
+import static jakarta.security.jacc.PolicyContext.SUBJECT;
+import static java.lang.System.Logger.Level.DEBUG;
+import static java.lang.System.Logger.Level.ERROR;
+import static java.util.Collections.emptySet;
+import static org.glassfish.exousia.constraints.transformer.ConstraintsToPermissionsTransformer.createResourceAndDataPermissions;
+import static org.glassfish.exousia.permissions.RolesToPermissionsTransformer.createWebRoleRefPermission;
 
 /**
  *
@@ -206,12 +212,33 @@ public class AuthorizationService {
         this.constrainedUriRequestAttribute = constrainedUriRequestAttribute;
     }
 
-    public void addConstraintsToPolicy(List<SecurityConstraint> securityConstraints, Set<String> declaredRoles, boolean isDenyUncoveredHttpMethods, Map<String, List<SecurityRoleRef>> servletRoleMappings) {
+    public void addConstraintsToPolicy(JakartaPermissions stagedPermissions, List<SecurityConstraint> securityConstraints, Set<String> declaredRoles, boolean isDenyUncoveredHttpMethods, Map<String, List<SecurityRoleRef>> servletRoleMappings) {
         try {
-            JakartaPermissions jakartaResourceDataPermissions = createResourceAndDataPermissions(declaredRoles, isDenyUncoveredHttpMethods, securityConstraints);
+            // 1. Convert simple staged WebResourcePermission entries into SecurityConstraint.
+            StagedPermissionToConstraintResult stagedConstraintResult =
+                StagedPermissionsToConstraintsTransformer.transform(stagedPermissions);
+
+            // 2. Merge web.xml / servlet constraints with REST-derived constraints.
+            List<SecurityConstraint> mergedConstraints = new ArrayList<>();
+            mergedConstraints.addAll(securityConstraints);
+            mergedConstraints.addAll(stagedConstraintResult.securityConstraints());
+
+            // 3. Run the existing closed-world transformer over the whole universe.
+            JakartaPermissions jakartaResourceDataPermissions =
+                createResourceAndDataPermissions(
+                    declaredRoles,
+                    isDenyUncoveredHttpMethods,
+                    mergedConstraints);
+
             addPermissionsToPolicy(jakartaResourceDataPermissions);
 
-            JakartaPermissions jakartaRoleRefPermissions = createWebRoleRefPermission(declaredRoles, servletRoleMappings);
+            // 4. Preserve any non-resource permissions that were already staged.
+            addPermissionsToPolicy(stagedConstraintResult.passThroughPermissions());
+
+            // 5. Add servlet role-ref permissions
+            JakartaPermissions jakartaRoleRefPermissions =
+                createWebRoleRefPermission(declaredRoles, servletRoleMappings);
+
             addPermissionsToPolicy(jakartaRoleRefPermissions);
 
         } catch (PolicyContextException e) {

--- a/impl/src/main/java/org/glassfish/exousia/constraints/transformer/StagedPermissionToConstraintResult.java
+++ b/impl/src/main/java/org/glassfish/exousia/constraints/transformer/StagedPermissionToConstraintResult.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.exousia.constraints.transformer;
+
+import java.util.List;
+
+import org.glassfish.exousia.constraints.SecurityConstraint;
+import org.glassfish.exousia.permissions.JakartaPermissions;
+
+public record StagedPermissionToConstraintResult(List<SecurityConstraint> securityConstraints, JakartaPermissions passThroughPermissions) {
+}

--- a/impl/src/main/java/org/glassfish/exousia/constraints/transformer/StagedPermissionsToConstraintsTransformer.java
+++ b/impl/src/main/java/org/glassfish/exousia/constraints/transformer/StagedPermissionsToConstraintsTransformer.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.exousia.constraints.transformer;
+
+import jakarta.security.jacc.WebResourcePermission;
+
+import java.security.Permission;
+import java.security.PermissionCollection;
+import java.security.Permissions;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.glassfish.exousia.constraints.SecurityConstraint;
+import org.glassfish.exousia.constraints.WebResourceCollection;
+import org.glassfish.exousia.permissions.JakartaPermissions;
+
+import static jakarta.servlet.annotation.ServletSecurity.TransportGuarantee.NONE;
+import static java.util.Collections.list;
+
+public final class StagedPermissionsToConstraintsTransformer {
+
+    private StagedPermissionsToConstraintsTransformer() {
+    }
+
+    public static StagedPermissionToConstraintResult transform(JakartaPermissions stagedPermissions) {
+        List<SecurityConstraint> constraints = new ArrayList<>();
+        JakartaPermissions passThrough = new JakartaPermissions();
+
+        if (stagedPermissions != null) {
+            convertExcluded(
+                stagedPermissions.getExcluded(),
+                constraints,
+                passThrough.getExcluded());
+
+            convertUnchecked(
+                stagedPermissions.getUnchecked(),
+                constraints,
+                passThrough.getUnchecked());
+
+            convertPerRole(
+                stagedPermissions.getPerRole(),
+                constraints,
+                passThrough.getPerRole());
+        }
+
+        return new StagedPermissionToConstraintResult(
+            List.copyOf(constraints),
+            passThrough);
+    }
+
+    private static void convertExcluded(PermissionCollection source, List<SecurityConstraint> constraints, Permissions passThrough) {
+        for (Permission permission : list(source.elements())) {
+            if (permission instanceof WebResourcePermission webResourcePermission) {
+                constraints.add(toExcludedConstraint(webResourcePermission));
+            } else {
+                passThrough.add(permission);
+            }
+        }
+    }
+
+    private static void convertUnchecked(PermissionCollection source, List<SecurityConstraint> constraints, Permissions passThrough) {
+        for (Permission permission : list(source.elements())) {
+            if (permission instanceof WebResourcePermission webResourcePermission) {
+                constraints.add(toUncheckedConstraint(webResourcePermission));
+            } else {
+                passThrough.add(permission);
+            }
+        }
+    }
+
+    private static void convertPerRole(Map<String, Permissions> source, List<SecurityConstraint> constraints, Map<String, Permissions> passThrough) {
+        Map<PermissionKey, Set<String>> rolesByPermission = new LinkedHashMap<>();
+
+        for (Map.Entry<String, Permissions> roleEntry : source.entrySet()) {
+            String role = roleEntry.getKey();
+
+            for (Permission permission : list(roleEntry.getValue().elements())) {
+                if (permission instanceof WebResourcePermission webResourcePermission) {
+                    PermissionKey key = PermissionKey.of(webResourcePermission);
+
+                    rolesByPermission.computeIfAbsent(key, ignored -> new LinkedHashSet<>()).add(role);
+                } else {
+                    passThrough.computeIfAbsent(role, ignored -> new Permissions()).add(permission);
+                }
+            }
+        }
+
+        for (Map.Entry<PermissionKey, Set<String>> entry : rolesByPermission.entrySet()) {
+            constraints.add(toRoleConstraint(entry.getKey(), entry.getValue()));
+        }
+    }
+
+    private static SecurityConstraint toExcludedConstraint(
+            WebResourcePermission permission) {
+
+        return toConstraint(
+            requireSimpleUrlPattern(permission.getName()),
+            MethodSelector.fromActions(permission.getActions()),
+            Set.of());
+    }
+
+    private static SecurityConstraint toUncheckedConstraint(
+            WebResourcePermission permission) {
+
+        return toConstraint(
+            requireSimpleUrlPattern(permission.getName()),
+            MethodSelector.fromActions(permission.getActions()),
+            null);
+    }
+
+    private static SecurityConstraint toRoleConstraint(
+            PermissionKey permissionKey,
+            Set<String> roles) {
+
+        return toConstraint(
+            requireSimpleUrlPattern(permissionKey.name()),
+            MethodSelector.fromActions(permissionKey.actions()),
+            Set.copyOf(roles));
+    }
+
+    /**
+     * rolesAllowed interpretation used here:
+     *
+     * null      -> no auth-constraint, unchecked
+     * empty     -> auth-constraint with no roles, excluded
+     * non-empty -> auth-constraint with roles
+     */
+    private static SecurityConstraint toConstraint(String urlPattern, MethodSelector methodSelector, Set<String> rolesAllowed) {
+        WebResourceCollection webResourceCollection =
+                new WebResourceCollection(
+                        Set.of(urlPattern),
+                        methodSelector.httpMethods(),
+                        methodSelector.httpMethodOmissions());
+
+        return
+            new SecurityConstraint(List.of(webResourceCollection), rolesAllowed, NONE);
+
+    }
+
+    private static String requireSimpleUrlPattern(String name) {
+        if (name == null) {
+            throw new IllegalArgumentException(
+                "Staged WebResourcePermission name must not be null");
+        }
+
+        if (name.indexOf(':') >= 0) {
+            throw new IllegalArgumentException(
+                "Staged WebResourcePermission must not already be a qualified URLPatternSpec: "
+                    + name);
+        }
+
+        if (name.indexOf('{') >= 0 || name.indexOf('}') >= 0) {
+            throw new IllegalArgumentException(
+                "JAX-RS template paths are not supported in this temporary bridge: "
+                    + name);
+        }
+
+        return name;
+    }
+
+    private record PermissionKey(
+            String name,
+            String actions) {
+
+        static PermissionKey of(WebResourcePermission permission) {
+            return new PermissionKey(
+                permission.getName(),
+                normalizeActions(permission.getActions()));
+        }
+
+        private static String normalizeActions(String actions) {
+            if (actions == null || actions.isBlank()) {
+                return null;
+            }
+
+            return actions.trim();
+        }
+    }
+
+    private record MethodSelector(Set<String> httpMethods, Set<String> httpMethodOmissions) {
+
+        static MethodSelector fromActions(String actions) {
+            if (actions == null || actions.isBlank()) {
+                // Empty httpMethods + empty httpMethodOmissions means all methods.
+                return new MethodSelector(Set.of(), Set.of());
+            }
+
+            String normalizedActions = actions.trim();
+
+            if (normalizedActions.startsWith("!")) {
+                return new MethodSelector(Set.of(), splitMethods(normalizedActions.substring(1)));
+            }
+
+            return new MethodSelector(splitMethods(normalizedActions), Set.of());
+        }
+
+        private static Set<String> splitMethods(String actions) {
+            if (actions == null || actions.isBlank()) {
+                return Set.of();
+            }
+
+            Set<String> methods = new LinkedHashSet<>();
+
+            for (String action : actions.split(",")) {
+                String method = action.trim();
+
+                if (!method.isEmpty()) {
+                    methods.add(method);
+                }
+            }
+
+            return Set.copyOf(methods);
+        }
+    }
+
+}

--- a/impl/src/main/java/org/glassfish/exousia/modules/def/DefaultPolicy.java
+++ b/impl/src/main/java/org/glassfish/exousia/modules/def/DefaultPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2023, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2019, 2021 OmniFaces. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -42,7 +42,6 @@ import static java.util.Collections.list;
 public class DefaultPolicy implements Policy {
 
     private PolicyConfigurationFactory policyConfigurationFactory;
-    private PrincipalMapper principalMapper;
 
     @Override
     public boolean isExcluded(Permission permissionToBeChecked) {

--- a/impl/src/main/java/org/glassfish/exousia/permissions/RolesToPermissionsTransformer.java
+++ b/impl/src/main/java/org/glassfish/exousia/permissions/RolesToPermissionsTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2024, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -31,7 +31,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.BiFunction;
 
-import org.glassfish.exousia.constraints.transformer.ConstraintsToPermissionsTransformer;
 import org.glassfish.exousia.mapping.SecurityRoleRef;
 
 import static java.lang.System.Logger.Level.DEBUG;
@@ -47,8 +46,6 @@ public class RolesToPermissionsTransformer {
     private static final Logger LOG = System.getLogger(RolesToPermissionsTransformer.class.getName());
 
     public static final String ANY_AUTHENTICATED_CALLER_ROLE = "**";
-
-    private static final String CLASS_NAME = ConstraintsToPermissionsTransformer.class.getSimpleName();
 
     private static final BiFunction<String, String, Permission> CREATE_BEAN_REF = EJBRoleRefPermission::new;
     private static final BiFunction<String, String, Permission> CREATE_WEB_REF = WebRoleRefPermission::new;

--- a/impl/src/test/java/org/glassfish/exousia/test/TransformTest.java
+++ b/impl/src/test/java/org/glassfish/exousia/test/TransformTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.exousia.test;
+
+import java.util.List;
+import java.util.Set;
+
+import org.glassfish.exousia.constraints.SecurityConstraint;
+import org.glassfish.exousia.constraints.WebResourceCollection;
+import org.glassfish.exousia.constraints.transformer.ConstraintsToPermissionsTransformer;
+import org.glassfish.exousia.permissions.JakartaPermissions;
+import org.junit.Test;
+
+import static jakarta.servlet.annotation.ServletSecurity.TransportGuarantee.CONFIDENTIAL;
+import static java.util.Arrays.asList;
+
+public class TransformTest {
+
+
+    @Test
+    public void transformTestNoMethods() {
+        JakartaPermissions permissions =
+            ConstraintsToPermissionsTransformer.createResourceAndDataPermissions(
+                Set.of("foo", "bar"),
+                false,
+                List.of(
+                    new SecurityConstraint(
+                        asList(
+                            new WebResourceCollection("/*")),
+                        null,
+                        CONFIDENTIAL)));
+
+        System.out.println("Excluded\n" + permissions.getExcluded());
+        System.out.println("Unchecked\n" + permissions.getUnchecked());
+        System.out.println("Per role\n" + permissions.getPerRole());
+    }
+
+    @Test
+    public void transformTestMethods() {
+        JakartaPermissions permissions =
+            ConstraintsToPermissionsTransformer.createResourceAndDataPermissions(
+                Set.of("foo", "bar"),
+                false,
+                List.of(
+                    new SecurityConstraint(
+                        asList(
+                            new WebResourceCollection(
+                                Set.of(
+                                    "/*"),
+                                Set.of(
+                                    "GET",
+                                    "HEAD",
+                                    "POST",
+                                    "PUT",
+                                    "DELETE",
+                                    "CONNECT",
+                                    "OPTIONS",
+                                    "TRACE",
+                                    "PATCH"))),
+                        null,
+                        CONFIDENTIAL)));
+
+        System.out.println("Excluded\n" + permissions.getExcluded());
+        System.out.println("Unchecked\n" + permissions.getUnchecked());
+        System.out.println("Per role\n" + permissions.getPerRole());
+    }
+
+    @Test
+    public void transformTestMethodsDenyUncoveredHttpMethods() {
+        JakartaPermissions permissions =
+            ConstraintsToPermissionsTransformer.createResourceAndDataPermissions(
+                Set.of("foo", "bar"),
+                true, // isDenyUncoveredHttpMethods
+                List.of(
+                    new SecurityConstraint(
+                        asList(
+                            new WebResourceCollection(
+                                Set.of(
+                                    "/*"),
+                                Set.of(
+                                    "GET",
+                                    "HEAD",
+                                    "POST",
+                                    "PUT",
+                                    "DELETE",
+                                    "CONNECT",
+                                    "OPTIONS",
+                                    "TRACE",
+                                    "PATCH"))),
+                        null,
+                        CONFIDENTIAL)));
+
+        System.out.println("Excluded\n" + permissions.getExcluded());
+        System.out.println("Unchecked\n" + permissions.getUnchecked());
+        System.out.println("Per role\n" + permissions.getPerRole());
+    }
+
+
+}

--- a/spi/tomcat/src/main/java/org/glassfish/exousia/spi/tomcat/TomcatAuthorizationFilter.java
+++ b/spi/tomcat/src/main/java/org/glassfish/exousia/spi/tomcat/TomcatAuthorizationFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2023, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2020, 2021 OmniFaces. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -85,7 +85,7 @@ public class TomcatAuthorizationFilter extends HttpFilter implements ServletRequ
         // Copy all the security constraints that Tomcat has collected to the Jakarta Authorization
         // repository as well. That way Jakarta Authorization can work with the same data as Tomcat
         // internally does.
-        authorizationService.addConstraintsToPolicy(
+        authorizationService.addConstraintsToPolicy(null,
             convertTomcatConstraintsToExousia(constraints),
             new HashSet<>(declaredRoles), isDenyUncoveredHttpMethods, emptyMap());
 


### PR DESCRIPTION
These permissions are intended to be provided by a Jakarta Security implementation (e.g. Soteria) which discovers @RolesAllowed and @PermitAll etc annotations on REST endpoints.

This is a first phase implementation that only support simple REST endpoints (without template features)

See https://github.com/jakartaee/security/issues/295