### PR TITLE
Add a preliminary RestResourcePermission with support code

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
-            <version>6.2.0-M1</version>
+            <version>6.2.0-M2</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
@@ -107,7 +107,7 @@
         <dependency>
             <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
-            <version>3.30.2-GA</version>
+            <version>3.32.0-GA</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
@@ -175,7 +175,7 @@
             
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.14.1</version>
+                <version>3.15.0</version>
                 <configuration>
                     <release>17</release>
                 </configuration>
@@ -186,7 +186,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>6.0.0</version>
+                <version>6.0.2</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>

--- a/impl/src/main/java/org/glassfish/exousia/AuthorizationService.java
+++ b/impl/src/main/java/org/glassfish/exousia/AuthorizationService.java
@@ -56,6 +56,7 @@ import org.glassfish.exousia.mapping.SecurityRoleRef;
 import org.glassfish.exousia.modules.def.DefaultPolicy;
 import org.glassfish.exousia.modules.def.DefaultPolicyConfigurationFactory;
 import org.glassfish.exousia.permissions.JakartaPermissions;
+import org.glassfish.exousia.permissions.RestResourcePermission;
 
 import static jakarta.security.jacc.PolicyContext.HTTP_SERVLET_REQUEST;
 import static jakarta.security.jacc.PolicyContext.PRINCIPAL_MAPPER;
@@ -63,6 +64,9 @@ import static jakarta.security.jacc.PolicyContext.SUBJECT;
 import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.ERROR;
 import static java.util.Collections.emptySet;
+import static org.glassfish.exousia.AuthorizationService.PermissionCheckResult.DENIED;
+import static org.glassfish.exousia.AuthorizationService.PermissionCheckResult.GRANTED;
+import static org.glassfish.exousia.AuthorizationService.PermissionCheckResult.NOT_APPLICABLE;
 import static org.glassfish.exousia.constraints.transformer.ConstraintsToPermissionsTransformer.createResourceAndDataPermissions;
 import static org.glassfish.exousia.permissions.RolesToPermissionsTransformer.createWebRoleRefPermission;
 
@@ -90,6 +94,14 @@ public class AuthorizationService {
     private final Map<String, jakarta.security.jacc.PrincipalMapper> principalMapper = new ConcurrentHashMap<>();
 
     private String constrainedUriRequestAttribute;
+
+    private final Permissions restResourcePermissions = new Permissions();
+
+    public static enum PermissionCheckResult {
+        NOT_APPLICABLE,
+        GRANTED,
+        DENIED
+    }
 
     public AuthorizationService(
             ServletContext servletContext,
@@ -233,7 +245,13 @@ public class AuthorizationService {
             addPermissionsToPolicy(jakartaResourceDataPermissions);
 
             // 4. Preserve any non-resource permissions that were already staged.
+            //    (Currently this should only be RestResourcePermissions)
             addPermissionsToPolicy(stagedConstraintResult.passThroughPermissions());
+
+            // 4.1 Collect Rest permissions to be able to do an applicable check.
+            //     TODO: May replace this later with a closed-world transformer
+            //           like we do for Web permissions
+            collectRestResourcePermissions(stagedConstraintResult.passThroughPermissions());
 
             // 5. Add servlet role-ref permissions
             JakartaPermissions jakartaRoleRefPermissions =
@@ -473,6 +491,64 @@ public class AuthorizationService {
                 principals);
     }
 
+    public PermissionCheckResult checkRestResourcePermissionIfApplicable(HttpServletRequest request) {
+        try {
+            Subject subject = PolicyContext.getContext(SUBJECT);
+
+            return checkRestResourcePermissionIfApplicable(
+                request,
+                subject);
+        } catch (PolicyContextException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    public PermissionCheckResult checkRestResourcePermissionIfApplicable(HttpServletRequest request, Subject subject) {
+        RestResourcePermission requestedPermission =
+            new RestResourcePermission(
+                getRestPath(request),
+                request.getMethod());
+
+        if (!restResourcePermissions.implies(requestedPermission)) {
+            return NOT_APPLICABLE;
+        }
+
+        return checkPermission(requestedPermission, subject)
+            ? GRANTED
+            : DENIED;
+    }
+
+    public PermissionCheckResult checkRestResourcePermissionIfApplicable(HttpServletRequest request, Set<Principal> principals) {
+        RestResourcePermission requestedPermission =
+            new RestResourcePermission(
+                getRestPath(request),
+                request.getMethod());
+
+        if (!restResourcePermissions.implies(requestedPermission)) {
+            return NOT_APPLICABLE;
+        }
+
+        return checkPermission(requestedPermission, principals)
+            ? GRANTED
+            : DENIED;
+    }
+
+    public boolean checkRestResourcePermission(HttpServletRequest request, Set<Principal> principals) {
+        return checkPermission(
+            new RestResourcePermission(
+                getRestPath(request),
+                request.getMethod()),
+            principals);
+    }
+
+    public boolean checkRestResourcePermission(HttpServletRequest request, Subject subject) {
+        return checkPermission(
+            new RestResourcePermission(
+                getRestPath(request),
+                request.getMethod()),
+            subject);
+    }
+
     public boolean checkWebRoleRefPermission(String servletName, String role) {
         try {
             Subject subject = PolicyContext.getContext(SUBJECT);
@@ -696,6 +772,21 @@ public class AuthorizationService {
         }
     }
 
+    private void collectRestResourcePermissions(JakartaPermissions permissions) {
+        collectRestResourcePermissions(permissions.getExcluded());
+        collectRestResourcePermissions(permissions.getUnchecked());
+
+        permissions.getPerRole()
+                   .values()
+                   .forEach(this::collectRestResourcePermissions);
+    }
+
+    private void collectRestResourcePermissions(Permissions permissions) {
+        permissions.elementsAsStream()
+                   .filter(RestResourcePermission.class::isInstance)
+                   .forEach(restResourcePermissions::add);
+    }
+
     private Policy getPolicy() {
         if (policy != null) {
             return policy;
@@ -726,6 +817,14 @@ public class AuthorizationService {
         }
 
         return relativeURI.replace(":", "%3A");
+    }
+
+    private String getRestPath(HttpServletRequest request) {
+        String path =
+            request.getRequestURI()
+                   .substring(request.getContextPath().length());
+
+        return path.isEmpty() ? "/" : path;
     }
 
     private PrincipalMapper getOrCreatePrincipalMapper(String contextId, Supplier<PrincipalMapper> principalMapperSupplier) {

--- a/impl/src/main/java/org/glassfish/exousia/permissions/RestResourcePermission.java
+++ b/impl/src/main/java/org/glassfish/exousia/permissions/RestResourcePermission.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.exousia.permissions;
+
+import java.security.Permission;
+import java.util.Locale;
+import java.util.Objects;
+
+import static org.glassfish.exousia.permissions.RestUriTemplate.RightHandPath.CLOSED;
+
+/**
+ * Permission for Jakarta REST resource paths.
+ *
+ * <p>The permission name is a context-relative REST URI path template, for example:
+ *
+ * <pre>
+ * /rest/users/{username: [A-Z][a-zA-Z_0-9]*}
+ * </pre>
+ *
+ * <p>The action is the HTTP method, for example {@code GET}, {@code POST}, or {@code DELETE}.
+ *
+ * <p>A stored permission implies a requested permission when:
+ *
+ * <ul>
+ *   <li>the HTTP method matches; and</li>
+ *   <li>the stored URI template matches the requested actual path.</li>
+ * </ul>
+ */
+public final class RestResourcePermission extends Permission {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String path;
+    private final String httpMethod;
+    private final String actions;
+    private final RestUriTemplate template;
+
+    public RestResourcePermission(String path, String httpMethod) {
+        super(RestUriTemplate.normalizePath(path));
+
+        this.path = RestUriTemplate.normalizePath(path);
+        this.httpMethod = normalizeHttpMethod(httpMethod);
+        this.actions = this.httpMethod == null ? "" : this.httpMethod;
+
+        /*
+         * RestResourcePermission is intended for full discovered resource method
+         * paths, so use closed matching:
+         *
+         *   /rest/foo/{id}  matches  /rest/foo/1
+         *   /rest/foo/{id}  matches  /rest/foo/1/
+         *   /rest/foo/{id}  rejects   /rest/foo/1/extra
+         *
+         * If we later need staged class/sub-resource matching, we can add a
+         * factory or constructor variant that uses RightHandPath.OPEN.
+         */
+        this.template = new RestUriTemplate(this.path, CLOSED);
+    }
+
+    @Override
+    public boolean implies(Permission permission) {
+        if (!(permission instanceof RestResourcePermission other)) {
+            return false;
+        }
+
+        return methodImplies(other.httpMethod)
+            && template.matches(other.path);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof RestResourcePermission permission)) {
+            return false;
+        }
+
+        return path.equals(permission.path)
+            && Objects.equals(httpMethod, permission.httpMethod);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(path, httpMethod);
+    }
+
+    @Override
+    public String getActions() {
+        return actions;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public String getHttpMethod() {
+        return httpMethod;
+    }
+
+    private boolean methodImplies(String requestedMethod) {
+        return httpMethod == null
+            || "*".equals(httpMethod)
+            || httpMethod.equals(requestedMethod);
+    }
+
+    private static String normalizeHttpMethod(String method) {
+        if (method == null || method.isBlank() || "*".equals(method.trim())) {
+            return null;
+        }
+
+        return method.trim().toUpperCase(Locale.ROOT);
+    }
+}

--- a/impl/src/main/java/org/glassfish/exousia/permissions/RestUriTemplate.java
+++ b/impl/src/main/java/org/glassfish/exousia/permissions/RestUriTemplate.java
@@ -1,0 +1,390 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.exousia.permissions;
+
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * Minimal Jakarta REST URI path template compiler for authorization purposes.
+ *
+ * <p>This class intentionally does not depend on Jersey. It implements the
+ * subset of Jakarta REST URI template matching needed by {@link RestResourcePermission}:
+ *
+ * <ul>
+ *   <li>literal path characters are URI encoded and regex escaped;</li>
+ *   <li>{@code {name}} matches one path segment;</li>
+ *   <li>{@code {name: regex}} uses the supplied regex;</li>
+ *   <li>template variable names are ignored for matching;</li>
+ *   <li>right-hand-path matching can be open or closed.</li>
+ * </ul>
+ */
+final class RestUriTemplate {
+
+    private static final String DEFAULT_VARIABLE_REGEX = "[^/]+?";
+
+    enum RightHandPath {
+        /**
+         * Matches zero or more remaining path segments. This mirrors the
+         * Jakarta REST R(A) function used during staged request matching.
+         */
+        OPEN("(/.*)?"),
+
+        /**
+         * Matches no remaining path segment except an optional trailing slash.
+         * This is the preferred mode for a full resource-method permission.
+         */
+        CLOSED("(/)?");
+
+        private final String regex;
+
+        RightHandPath(String regex) {
+            this.regex = regex;
+        }
+    }
+
+    private final String template;
+    private final Pattern pattern;
+
+    RestUriTemplate(String template, RightHandPath rightHandPath) {
+        this.template = normalizeTemplate(template);
+        this.pattern = Pattern.compile(toRegex(this.template, rightHandPath));
+    }
+
+    boolean matches(String path) {
+        return pattern.matcher(normalizePath(path)).matches();
+    }
+
+    String template() {
+        return template;
+    }
+
+    Pattern pattern() {
+        return pattern;
+    }
+
+    private static String toRegex(String template, RightHandPath rightHandPath) {
+        StringBuilder regex = new StringBuilder();
+
+        StringBuilder literal = new StringBuilder();
+        for (int i = 0; i < template.length();) {
+            char c = template.charAt(i);
+
+            if (c == '{') {
+                appendLiteralRegex(regex, literal);
+                literal.setLength(0);
+
+                Variable variable = parseVariable(template, i);
+                regex.append('(')
+                     .append(variable.regex())
+                     .append(')');
+
+                i = variable.endIndex() + 1;
+            } else {
+                literal.append(c);
+                i++;
+            }
+        }
+
+        appendLiteralRegex(regex, literal);
+
+        if (!regex.isEmpty() && regex.charAt(regex.length() - 1) == '/') {
+            regex.setLength(regex.length() - 1);
+        }
+
+        regex.append(rightHandPath.regex);
+
+        try {
+            Pattern.compile(regex.toString());
+        } catch (PatternSyntaxException e) {
+            throw new IllegalArgumentException(
+                "Invalid REST URI template regex for template " + template + ": " + regex, e);
+        }
+
+        return regex.toString();
+    }
+
+    private static Variable parseVariable(String template, int openIndex) {
+        StringBuilder name = new StringBuilder();
+        StringBuilder explicitRegex = new StringBuilder();
+
+        boolean inRegex = false;
+        boolean escaped = false;
+        int characterClassDepth = 0;
+        int regexBraceDepth = 0;
+        int regexParenthesisDepth = 0;
+
+        for (int i = openIndex + 1; i < template.length(); i++) {
+            char c = template.charAt(i);
+
+            if (!inRegex) {
+                if (c == ':') {
+                    inRegex = true;
+                    continue;
+                }
+
+                if (c == '}') {
+                    String variableName = name.toString().trim();
+                    validateVariableName(variableName, template);
+                    return new Variable(variableName, DEFAULT_VARIABLE_REGEX, i);
+                }
+
+                name.append(c);
+                continue;
+            }
+
+            if (escaped) {
+                explicitRegex.append(c);
+                escaped = false;
+                continue;
+            }
+
+            if (c == '\\') {
+                explicitRegex.append(c);
+                escaped = true;
+                continue;
+            }
+
+            if (c == '[') {
+                characterClassDepth++;
+                explicitRegex.append(c);
+                continue;
+            }
+
+            if (c == ']' && characterClassDepth > 0) {
+                characterClassDepth--;
+                explicitRegex.append(c);
+                continue;
+            }
+
+            if (characterClassDepth == 0) {
+                if (c == '(') {
+                    regexParenthesisDepth++;
+                    explicitRegex.append(c);
+                    continue;
+                }
+
+                if (c == ')' && regexParenthesisDepth > 0) {
+                    regexParenthesisDepth--;
+                    explicitRegex.append(c);
+                    continue;
+                }
+
+                if (c == '{') {
+                    regexBraceDepth++;
+                    explicitRegex.append(c);
+                    continue;
+                }
+
+                if (c == '}' && regexBraceDepth > 0) {
+                    regexBraceDepth--;
+                    explicitRegex.append(c);
+                    continue;
+                }
+
+                if (c == '}' && regexParenthesisDepth == 0) {
+                    String variableName = name.toString().trim();
+                    String regex = explicitRegex.toString().trim();
+
+                    validateVariableName(variableName, template);
+
+                    return new Variable(
+                        variableName,
+                        regex.isEmpty() ? "" : regex,
+                        i);
+                }
+            }
+
+            explicitRegex.append(c);
+        }
+
+        throw new IllegalArgumentException("Unterminated REST URI template variable in: " + template);
+    }
+
+    private static void validateVariableName(String name, String template) {
+        if (name.isEmpty()) {
+            throw new IllegalArgumentException("Empty REST URI template variable name in: " + template);
+        }
+
+        char first = name.charAt(0);
+        if (!Character.isLetterOrDigit(first) && first != '_') {
+            throw new IllegalArgumentException(
+                "Illegal REST URI template variable name '" + name + "' in: " + template);
+        }
+
+        for (int i = 1; i < name.length(); i++) {
+            char c = name.charAt(i);
+
+            if (!Character.isLetterOrDigit(c) && c != '_' && c != '-' && c != '.') {
+                throw new IllegalArgumentException(
+                    "Illegal REST URI template variable name '" + name + "' in: " + template);
+            }
+        }
+    }
+
+    private static void appendLiteralRegex(StringBuilder regex, StringBuilder literal) {
+        if (literal.isEmpty()) {
+            return;
+        }
+
+        appendEncodedLiteralRegex(regex, literal.toString());
+    }
+
+    /**
+     * URI-encodes literal path characters and escapes regex metacharacters.
+     *
+     * <p>Existing percent-encoded octets are preserved and matched
+     * case-insensitively, following Jersey's useful behavior for hex digits.
+     */
+    private static void appendEncodedLiteralRegex(StringBuilder regex, String literal) {
+        for (int i = 0; i < literal.length();) {
+            char c = literal.charAt(i);
+
+            if (c == '%' && i + 2 < literal.length()
+                    && isHex(literal.charAt(i + 1))
+                    && isHex(literal.charAt(i + 2))) {
+
+                regex.append('%');
+                appendHexRegex(regex, literal.charAt(i + 1));
+                appendHexRegex(regex, literal.charAt(i + 2));
+                i += 3;
+                continue;
+            }
+
+            int codePoint = literal.codePointAt(i);
+
+            if (isAllowedPathLiteral(codePoint)) {
+                appendRegexEscaped(regex, (char) codePoint);
+            } else {
+                byte[] bytes = new String(Character.toChars(codePoint))
+                    .getBytes(StandardCharsets.UTF_8);
+
+                for (byte b : bytes) {
+                    appendPercentEncodedByteRegex(regex, b);
+                }
+            }
+
+            i += Character.charCount(codePoint);
+        }
+    }
+
+    /**
+     * Allows RFC 3986 pchar plus '/' because this is a path template, not a
+     * single path segment.
+     */
+    private static boolean isAllowedPathLiteral(int codePoint) {
+        if (codePoint > 0x7F) {
+            return false;
+        }
+
+        char c = (char) codePoint;
+
+        return isUnreserved(c)
+            || isSubDelimiter(c)
+            || c == ':'
+            || c == '@'
+            || c == '/';
+    }
+
+    private static boolean isUnreserved(char c) {
+        return (c >= 'A' && c <= 'Z')
+            || (c >= 'a' && c <= 'z')
+            || (c >= '0' && c <= '9')
+            || c == '-'
+            || c == '.'
+            || c == '_'
+            || c == '~';
+    }
+
+    private static boolean isSubDelimiter(char c) {
+        return c == '!'
+            || c == '$'
+            || c == '&'
+            || c == '\''
+            || c == '('
+            || c == ')'
+            || c == '*'
+            || c == '+'
+            || c == ','
+            || c == ';'
+            || c == '=';
+    }
+
+    private static void appendRegexEscaped(StringBuilder regex, char c) {
+        if (isRegexMetaCharacter(c)) {
+            regex.append('\\');
+        }
+
+        regex.append(c);
+    }
+
+    private static boolean isRegexMetaCharacter(char c) {
+        return c == '\\'
+            || c == '.'
+            || c == '^'
+            || c == '$'
+            || c == '|'
+            || c == '?'
+            || c == '*'
+            || c == '+'
+            || c == '('
+            || c == ')'
+            || c == '['
+            || c == ']'
+            || c == '{'
+            || c == '}';
+    }
+
+    private static void appendPercentEncodedByteRegex(StringBuilder regex, byte b) {
+        int value = b & 0xff;
+        regex.append('%');
+        appendHexRegex(regex, Character.toUpperCase(Character.forDigit((value >>> 4) & 0x0f, 16)));
+        appendHexRegex(regex, Character.toUpperCase(Character.forDigit(value & 0x0f, 16)));
+    }
+
+    private static void appendHexRegex(StringBuilder regex, char c) {
+        char upper = Character.toUpperCase(c);
+        char lower = Character.toLowerCase(c);
+
+        if (upper >= 'A' && upper <= 'F') {
+            regex.append('[').append(lower).append(upper).append(']');
+        } else {
+            regex.append(upper);
+        }
+    }
+
+    private static boolean isHex(char c) {
+        return (c >= '0' && c <= '9')
+            || (c >= 'a' && c <= 'f')
+            || (c >= 'A' && c <= 'F');
+    }
+
+    private static String normalizeTemplate(String template) {
+        return normalizePath(template);
+    }
+
+    static String normalizePath(String path) {
+        if (path == null || path.isBlank() || path.equals("/")) {
+            return "/";
+        }
+
+        String result = path.trim();
+
+        if (!result.startsWith("/")) {
+            result = "/" + result;
+        }
+
+        while (result.endsWith("/") && result.length() > 1) {
+            result = result.substring(0, result.length() - 1);
+        }
+
+        return result;
+    }
+
+    private record Variable(String name, String regex, int endIndex) {
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>2.0.2</version>
+        <version>2.0.4</version>
         <relativePath />
     </parent>
 

--- a/spi/tomcat/pom.xml
+++ b/spi/tomcat/pom.xml
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
-            <version>6.2.0-M1</version>
+            <version>6.2.0-M2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-catalina</artifactId>
-            <version>11.0.14</version>
+            <version>11.0.23</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
The RestResourcePermission allows us to reason about the security of a REST resource (endpoint) which uses a template path (path with embedded regex)